### PR TITLE
Update URLs to DOIs

### DIFF
--- a/data/E_neutralizing_plaque_serial_passage_escape.txt
+++ b/data/E_neutralizing_plaque_serial_passage_escape.txt
@@ -1,3 +1,3 @@
 # 12nt deletion detected after passage with neutralizing plaques
-# Sun et al. (2020) https://www.tandfonline.com/doi/figure/10.1080/22221751.2020.1837017?scroll=top&needAccess=true
+# Sun et al. (2020) https://doi.org/10.1080/22221751.2020.1837017
 F26del,L27del,L28del,V29del

--- a/data/M_immunosuppression_variant_emergence.txt
+++ b/data/M_immunosuppression_variant_emergence.txt
@@ -2,5 +2,5 @@
 # individual with chronic lymphocytic leukemia and acquired hypogammaglobulinemia. 
 # Variant became 100% in day 70 culture.
 # Variant disappeared after convalescent plasma treatment (day 71) in subsequent patient sample sequencing.
-# Avanzato et al. (2020) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7640888/
+# Avanzato et al. (2020) https://doi.org/10.1016%2Fj.cell.2020.10.049
 A2S

--- a/data/ORF6_IFN_activity.txt
+++ b/data/ORF6_IFN_activity.txt
@@ -1,3 +1,3 @@
 # The residues listed are determinants of the potent IFN-antagonistic activity of SARS-CoV-2 ORF6 (via blocking mRNA nuclear export)
-# Kimura et al. (2020) https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3690468
+# Kimura et al. (2020) https://dx.doi.org/10.2139/ssrn.3690468
 E46X,Q56X

--- a/data/ORF8_immunosuppression_variant_emergence.txt
+++ b/data/ORF8_immunosuppression_variant_emergence.txt
@@ -1,5 +1,5 @@
 # Emergent as 100% variant by day 70 post-infection of female immunocompromised 
 # individual with chronic lymphocytic leukemia and acquired hypogammaglobulinemia. 
 # Variant disappeared after convalescent plasma treatment (day 71) in subsequent patient sample sequencing.
-# Avanzato et al. (2020) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7640888/
+# Avanzato et al. (2020) https://doi.org/10.1016%2Fj.cell.2020.10.049
 K2N

--- a/data/PLPro_T_cell_evasion.txt
+++ b/data/PLPro_T_cell_evasion.txt
@@ -1,11 +1,11 @@
 # Found in lineage B.1.1.7, a.k.a. ORF1a A1708D, reduced recognition and T cell activation was observed in 
 # the 4 HLA-A2 positive post-infection sera tested vs wild type epitope AANFCALILA 1707,1716.
 # Markedly reduced recognition was also observed in 17 sera 1-3 months post Sinopharm vaccination.
-# Xiao et al. (2021) http://biorxiv.org/cgi/content/short/2021.03.28.437363
+# Xiao et al. (2021) https://doi.org/10.1101/2021.03.28.437363
 A890D
 
 # Found in lineage B.1.1.7, a.k.a. ORF1a I2230T, reduced recognition and T cell activation was observed in 
 # the 4 HLA-A2 positive post-infection sera tested vs overlapping wild type epitopes KLINIIIWFL 2225,2234 and IIWFLLLSV 2230,2238.
 # Markedly reduced recognition was also observed in 17 sera 1-3 months post Sinopharm vaccination.
-# Xiao et al. (2021) http://biorxiv.org/cgi/content/short/2021.03.28.437363
+# Xiao et al. (2021) https://doi.org/10.1101/2021.03.28.437363
 I1412T

--- a/data/RdRp_pharmaceutical_effectiveness.txt
+++ b/data/RdRp_pharmaceutical_effectiveness.txt
@@ -118,12 +118,12 @@ D483Y
 # Confers significant (5x) resistance in vitro to remdesivir [coordinates mapped from reported V553L in murine hepatitis virus model experiment to SARS-CoV-2].
 # Agostini et al. (2018) http://dx.doi.org/10.1128/mBio.00221-18
 # V556L mutation (incorrectly listed as V557L in the paper) is implicated in low-level resistance to Remdesivir.
-# Tchesnokov et al. (2020) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7681019/
+# Tchesnokov et al. (2020) https://doi.org/10.1074%2Fjbc.AC120.015720
 V556L 
 
 # S861G mutation (incorrectly listed as S861G in the paper) in RdRp eliminates chain-termination by Remdesivir, 
 # which confirms the existence of a steric clash between that residue and the incorporated RDV-TP
-# Tchesnokov et al. (2020) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7681019/
+# Tchesnokov et al. (2020) https://doi.org/10.1074%2Fjbc.AC120.015720
 S860G
 
 # Confers resistance (2.4x) in vitro to remdesivir [coordinates mapped from reported F476L in murine hepatitis virus model experiment to SARS-CoV-2].

--- a/data/S_ACE2_receptor_binding_affinity.txt
+++ b/data/S_ACE2_receptor_binding_affinity.txt
@@ -335,13 +335,13 @@ K417T;E484K;N501Y;D614G
 # Flow cytometry was used on recombinant VSV proteins and yeast surface display to assess the binding of a labeled soluble ACE2 
 # protein to cells expressing B.1.1.7. We observed a dramatic increase (relative to D614G) in binding of soluble 
 # ACE2 to B.1.1.7, and to a lesser extent to B.1.351, which both carry the N501Y mutation (see Fig 3). 
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 H69del;V70del;Y144del;N501Y;A570D;D614G;P681H;T716I;S982A;D1118H
 
 # Flow cytometry was used on recombinant VSV proteins and yeast surface display to assess the binding of a labeled soluble ACE2 
 # protein to cells expressing B.1.351. We observed an increase (relative to D614G) in binding of soluble 
 # ACE2 to B.1.351, and to a much gearter extent to B.1.1.7, which both carry the N501Y mutation (see Fig 3). 
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 L18F;D80A;D215G;L242del;K417N;E484K;N501Y;D614G;A701V
 
 # Lentiviral pseudotyped with the key mutations from COH.20G/677H lineage

--- a/data/S_ACE2_receptor_binding_affinity.txt
+++ b/data/S_ACE2_receptor_binding_affinity.txt
@@ -400,7 +400,7 @@ L18F;D80A;D215G;L242del;A243del;L244del;K417N;E484K;N501Y;D614G;A701V
 S494P
 
 # Six fold increase in affinity for ACE2 by the B.1.1.7 lineage vs wild type is driven by a drop in observed dissociation rate constant.
-# Collier et al. (2021) https://www.nature.com/articles/s41586-021-03412-7
+# Collier et al. (2021) https://doi.org/10.1038/s41586-021-03412-7
 # This mutation causes major decrease in binding affinity vs. wild type as measured by IC50 vs pseudotyped lentivirus.
 # Tada et al. (2021) https://www.biorxiv.org/content/10.1101/2021.02.05.430003v1
 H69del;V70del;Y144del;N501Y;A570D;P681H;T716I;S982A;D1118H
@@ -425,7 +425,7 @@ H69del;V70del;Y144del;N501Y;A570D;P681H;T716I;S982A;D1118H
 # Ramanathan et al. (2021) https://www.biorxiv.org/content/10.1101/2021.02.22.432359v1
 # This combination showed ~3x increase binding to ACE2 vs wild type, about half that of the B.1.1.7 lineage, suggesting
 # that the K417N mutation is slightly detrimental to ACE2 binding, probably as a result of disrupting the salt bridge formed with ACE2 residue D30
-# Collier et al. (2021) https://www.nature.com/articles/s41586-021-03412-7
+# Collier et al. (2021) https://doi.org/10.1038/s41586-021-03412-7
 K417N,E484K,N501Y
 
 # Reported 3-fold decrease in affinity compared to wild-type RBD on the cell surface (Kd = 145.1nM vs 56.9nM).

--- a/data/S_ACE2_receptor_binding_affinity.txt
+++ b/data/S_ACE2_receptor_binding_affinity.txt
@@ -474,24 +474,24 @@ Y453F
 N501Y
 
 # ~2-fold loss of binding affinity for the K417V variant relative to WT
-# Thomson et al. (2021) https://www.cell.com/cell/fulltext/S0092-8674(21)00080-5
+# Thomson et al. (2021) https://doi.org/10.1016/j.cell.2021.01.037
 # ~2-fold loss of binding affinity for the K417V variant relative to WT
 # Starr et al. (2020) https://doi.org/10.1016/j.cell.2020.08.012
 K417V
 
 # N439K creates a new RBD:hACE2 salt bridge while K417V removes one,
 # making this roughly a neutral combination in terms of binding affinity.
-# Thomson et al. (2021) https://www.cell.com/cell/fulltext/S0092-8674(21)00080-5
+# Thomson et al. (2021) https://doi.org/10.1016/j.cell.2021.01.037
 K417V,N439K
 
 # Enhances RBD:hACE2 affinity approximately 2-fold.
 # Observed that the N439K mutation results in viral fitness (culture-based) that is
 # similar or possibly slightly improved relative to the wild-type N439 virus
-# Thomson et al. (2021) https://www.cell.com/cell/fulltext/S0092-8674(21)00080-5
+# Thomson et al. (2021) https://doi.org/10.1016/j.cell.2021.01.037
 N439K
 
 # Enhances RBD:hACE2 affinity approximately 2-fold.
-# Thomson et al. (2021) https://www.cell.com/cell/fulltext/S0092-8674(21)00080-5
+# Thomson et al. (2021) https://doi.org/10.1016/j.cell.2021.01.037
 N439R
 
 # Minor variant in initial round of in vitro evolution experiment for ACE2 binding.

--- a/data/S_T_cell_evasion.txt
+++ b/data/S_T_cell_evasion.txt
@@ -136,20 +136,20 @@ L452R
 # Mutation is predicted to lose the T cell epitope for people carrying DRB1*0301 and DRB1*0401, 
 # but not for example in those who are DRB1*0701 or DRB1*1501 who would be predicted to show an enhanced response.
 # This is also observed in a study of 26 each post-infection and post first dose HCWs.
-# Reynolds et al. (2021) https://science.sciencemag.org/content/early/2021/04/29/science.abh1282
+# Reynolds et al. (2021) https://doi.org/10.1126/science.abh1282
 D1118H
 
 # Analyzing responses to the E484K mutation seen in B.1.351 and P.1 variants, we noted that it did 
 # not fall in a region predicted to bind the HLAII alleles tested (table S4). The mutation appeared 
 # to have no substantial or differential impact on T cell responses.
-# Reynolds et al. (2021) https://science.sciencemag.org/content/early/2021/04/29/science.abh1282
+# Reynolds et al. (2021) https://doi.org/10.1126/science.abh1282
 E484K
 
 # Vaccinated, but not post-infection sera, show decreased average T cell response to an N501Y peptide.
 # When we primed transgenic mice expressing human HLA-DRB1*0401 with the Wuhan Hu-1 peptide pool, 
 # T cell responses to the B.1.1.7 variant peptide pool were significantly reduced (p = 0.0286). 
 # Furthermore, the T cell response to the spike N501Y mutation common to all three of the current VOC was ablated.
-# Reynolds et al. (2021) https://science.sciencemag.org/content/early/2021/04/29/science.abh1282
+# Reynolds et al. (2021) https://doi.org/10.1126/science.abh1282
 N501Y
 
 # PBMCs of 11 mild COVID-19 patients collected 38-80 days after symptom onset

--- a/data/S_antibody_epitope_effects.txt
+++ b/data/S_antibody_epitope_effects.txt
@@ -1212,15 +1212,15 @@ L242del
 R246I
 
 # Markedly resistant to neutralizing antibodies, unlike most ablated N-glycosylation sites.
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 N234Q
 
 # Resistent to some neutralizing antibodies: mAbs X593 and P2B-2F6
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 L452R
 
 # Resistent to some neutralizing antibodies: mAbs X593 and P2B-2F6
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 # Ablates binding by class 3 mAbs such as C135 that do not directly interfere with ACE2 binding,
 # but clonal somatic mutations of memory B cells at 6.2 months (evolving humoral immune response)
 # show pronounced increase in binding to the variant.
@@ -1228,17 +1228,17 @@ L452R
 V483A
 
 # Resistent to some neutralizing antibodies: mAbs X593, 261-262, H4, and P2B-2F6
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 F490L
 
 # Resistent to some neutralizing antibodies: mAbs 157, 247, CB6, P2C-1F11, B38, and CA1
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 # Resistent to some class 1 (Spike 'up' conformation) antibodies tested.
 # Wang et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.15.426911v2
 A475V
 
 # Resistent to neutralizing mAb H00S022
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 # 6.8% of 442 tested post-infection sera showed a greater than two-fold
 # reduction in binding to N439K RBD as compared to WT. In some individuals, the >two-fold reduction diminished the RBD ED50 response below 30
 # a threshold previously determined to be a cutoff for specific binding
@@ -1294,39 +1294,39 @@ A475V
 Q493R
 
 # Resistent to neutralizing mAb H014
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 Y508H
 
 # Resistent to neutralizing mAb B38
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 A831V
 
 # Resistent to neutralizing mAb X593 (on D614G background)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 I472V
 
 # Resistent to neutralizing mAb H014 (on D614G background)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 A435S
 
 # Increased sensitivity to neutralizing antibodies.
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 N165Q
 
 # Ablation of N-glycosylation site in RBD drastically reduces infectivity.
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 N331X
 
 # Ablation of N-glycosylation site in RBD drastically reduces infectivity (proline disallowed in N-X-S/T glycosylation pattern).
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 I332P
 
 # Ablation of N-glycosylation site in RBD drastically reduces infectivity.
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 N343X
 
 # Ablation of N-glycosylation site in RBD drastically reduces infectivity (proline disallowed in N-X-S/T glycosylation pattern).
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 I344P
 
 # Alters cleavage to occur between residues C15 and V16, thereby eliminating the C15-C136 disulfide bond – similarly to escape mutants at positions C15 and C136.

--- a/data/S_antibody_epitope_effects.txt
+++ b/data/S_antibody_epitope_effects.txt
@@ -1007,7 +1007,7 @@ H69del;V70del;Y144del;N501Y;A570D;D614G;P681H;T716I;S982A;D1118H
 D80A
 
 # 10-fold reduction in binding efficiency vs wild type for MAb REGN10933.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 Y453F
 
 # Resistent to class 2/3 antibody C603.
@@ -1053,7 +1053,7 @@ K444E
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows resistence to more than one antibody.
 # Liu et al. (2021) https://www.biorxiv.org/content/10.1101/2020.11.06.372037v2
 # Abolishes binding efficiency vs wild type for mAb REGN10933.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 K444N
 
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows resistence to more than one antibody.
@@ -1063,7 +1063,7 @@ G446D
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows resistence to more than one antibody.
 # Liu et al. (2021) https://www.biorxiv.org/content/10.1101/2020.11.06.372037v2
 # Massive reduction in binding efficiency vs wild type for mAb REGN10933.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 G446V
 
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows resistence to more than one antibody.
@@ -1151,7 +1151,7 @@ K417N
 # Pseudotyped virus model impairs neutralization by RBD-directed mAb COV2-2196 (somewhat more than fully pseudotyped B.1.351 or live virus)
 # Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 # Massive reduction in binding efficiency vs wild type for mAb LY-CoV555.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 E484K
 
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows high resistence to 4 antibodies, 
@@ -1162,7 +1162,7 @@ E484A
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows resistence to mAb 1B07.
 # Liu et al. (2020) https://www.biorxiv.org/content/10.1101/2020.11.06.372037v2
 # Massive reduction in binding efficiency vs wild type for mAb LY-CoV555.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 E484D
 
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows high resistence to 5 antibodies.
@@ -1180,7 +1180,7 @@ F490S
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows resistence to mAb SARS2-01.
 # Liu et al. (2020) https://www.biorxiv.org/content/10.1101/2020.11.06.372037v2
 # Greater than 10-fold rediuction of binding effeiency vs wild type for mAb LY-CoV555.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 S494P
 
 # Mutant screen in neutralization assay with a broad range of monoclonal antibodies shows high resistence to 3 antibodies.
@@ -1259,7 +1259,7 @@ N439K
 # Wang et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.15.426911v2
 # Greater than 10-fold reduction of binding effeiency vs wild type for mAb LY-CoV555.
 # Abolishes binding of mAb ADG-1.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 # N501Y substitution decreased the neutralizing and binding activities of CB6 and increased that of BD-23
 # Cheng et al. (2021) https://virologyj.biomedcentral.com/articles/10.1186/s12985-021-01554-8
 N440K
@@ -1290,7 +1290,7 @@ A475V
 # Mix of non- to strongly resistent in class 2 antibodies tested.
 # Wang et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.15.426911v2
 # Massive reduction in binding efficiency vs wild type for mAbs CB6/LY-CoV16 and LY-CoV555.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 Q493R
 
 # Resistent to neutralizing mAb H014

--- a/data/S_antibody_epitope_effects.txt
+++ b/data/S_antibody_epitope_effects.txt
@@ -1106,26 +1106,26 @@ T478I
 # Ablates ELISA test binding for class 2 (Spike 'up' or 'down' conformation, RBD targeting) monoclonal antibody P2B-2F6 on 501Y.V2 ("South African") lineage background
 # Wibmer et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.18.427166v1
 # Ablates Class 1 receptor-binding-motif targeting antibodies COV2-2050, 1B07, COVOX-384, and S2H58.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 K417N;E484K;N501Y
 
 # Ablates Class 1 receptor-binding-motif targeting antibodies COV2-2050, 1B07, COVOX-384, and S2H58.
 # Ablates Class 3 N-terminal domain targeting antibody COV2-2489, diminishes COV2-2676.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 E484K;N501Y
 
 # B.1.1.248 variant constellation ablates Class 1 receptor-binding-motif targeting antibodies COV2-2050, 1B07.
 # B.1.1.248 variant constellation ablates Class 3 N-terminal domain targeting antibody COV2-2676.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 L18F;T20N;P26S;D138Y;R190S;K417T;E484K;N501Y;D614G;H655Y;T1027I;V1176F
 
 # B.1.1.7 variant constellation ablates Class 3 N-terminal domain targeting antibody COV2-2489. 
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 H69del;V70del;Y144del;Y145del;N501Y;A570D;D614G;P681H
 
 # B.1.1.351 variant constellation ablates Class 1 receptor-binding-motif targeting antibodies COV2-2050, 1B07, COVOX-384, and S2H58.
 # B.1.1.351 variant constellation ablates Class 3 N-terminal domain targeting antibodies COV2-2489 and COV2-2676 (the only two tested). 
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 D80A;L242del;A243del;L244del;R246I;K417N;E484K;N501Y;D614G;A701V
 
 # 5 antibodies tested were less potent against K417N by ten-fold or more (class 1 mAbs)
@@ -1146,7 +1146,7 @@ K417N
 # or greater reduction in neutralization (plus notable reudction in two unclassfied mAbs).
 # Wang et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.15.426911v2
 # Ablates Class 1 receptor-binding-motif targeting antibodies COV2-2050, 1B07, COVOX-384 and S2H58.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w
 # Pseudotyped virus model ablates neutralization by RBD-directed mAbs 4-20, 2-4, 2-43, 2-30, 2-15, LY-Cov555, C121.
 # Pseudotyped virus model impairs neutralization by RBD-directed mAb COV2-2196 (somewhat more than fully pseudotyped B.1.351 or live virus)
 # Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
@@ -1405,7 +1405,7 @@ S254F
 # 4 antibodies tested were less potent against K417N by ten-fold or more, in both mAb classes 1 and 3
 # Wang et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.15.426911v2
 # Ablates Class 3 N-terminal domain targeting antibody COV2-2489, diminishes COV2-2676.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 # Reduction in neutralization by mAbs COVA1-18 (~4x), COVA2-15 (~9x), S309 (~3x)
 # Shen et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.27.428516v2
 # Lowered	the	neutralization potency of mAb COVA1-12 to the	limit	of the assay.
@@ -1424,7 +1424,7 @@ A570D
 # This variant is adjacent to the Spike protein furin cleavage site (cleavage of S into S1 and S2 subunits is required for viral membrane fusion and subsequent entry into host cells), a site shown to be highly immunogenic.
 # Johnson et al. (2020)  https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7457603/ 
 # Ablates Class 3 N-terminal domain targeting antibody COV2-2489, diminishes COV2-2676.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 P681H
 
 # Not in a major wildtype epitope, mutant increases PIWAS epitope score from 0.69% to 2.3%
@@ -1451,7 +1451,7 @@ W633P
 S686V
 
 # Ablates Class 3 N-terminal domain targeting antibody COV2-2489, diminishes COV2-2676.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 # Reduction in neutralization by mAbs COVA1-18 (~4x), COVA2-15 (~9x).
 # PG: these effects are laregly missing in the deletion-alone data
 # Shen et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.27.428516v2

--- a/data/S_antibody_epitope_effects.txt
+++ b/data/S_antibody_epitope_effects.txt
@@ -1422,7 +1422,7 @@ A570D
 # Together with other B1.1.7 lineage mutational changes (Spike: Y144del,N501Y, A570D Nucleoprotein: D3L, S235F) resulted in only 2 of 579 individuals (0.3% of the population) having a dramatic reduction in PIWAS antigen scores, which reflects the peak epitope signal along the entire antigen.
 # Haynes et al. (2021) https://www.medrxiv.org/content/10.1101/2021.01.06.20248960v1
 # This variant is adjacent to the Spike protein furin cleavage site (cleavage of S into S1 and S2 subunits is required for viral membrane fusion and subsequent entry into host cells), a site shown to be highly immunogenic.
-# Johnson et al. (2020)  https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7457603/ 
+# Johnson et al. (2020)  https://doi.org/10.1101%2F2020.08.26.268854 
 # Ablates Class 3 N-terminal domain targeting antibody COV2-2489, diminishes COV2-2676.
 # Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 P681H

--- a/data/S_antibody_epitope_effects.txt
+++ b/data/S_antibody_epitope_effects.txt
@@ -993,17 +993,17 @@ H69del;V70del;Y144del;N501Y;A570D;D614G;P681H;T716I;S982A;D1118H
 # B.1.351 pseudotyped virus model severely impairs neutralization by N-terminal-domain-directed mAb 2-17.
 # B.1.351 pseudotyped virus model impairs neutralization by N-terminal-domain-directed mAb 5-7.
 # PG: Live virus data for the same mAbs is similar, but 1-20 becomes severally impaired, REGN10933 activity is ablated, and Brii-196 becomes impaired.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 L18F;D80A;D215G;L242del;A243del;L244del;R246I;K417N;E484K;N501Y;D614G;A701V
 
 # B.1.1.7 pseudotyped virus model impairs binding by RBD-directed mAb 910-30.
 # B.1.1.7 pseudotyped virus model abolishes N-terminal-domain-directed mAbs 5-24, 4-8, and 4A8.
 # B.1.1.7 pseudotyped virus model impairs binding by N-terminal-domain-directed mAbs 2-17, 4-19, 5-7.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 H69del;V70del;Y144del;N501Y;A570D;D614G;P681H;T716I;S982A;D1118H
 
 # Abolishes neutralizing activity of N-terminal-domain-directed mAb 4-19.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 D80A
 
 # 10-fold reduction in binding efficiency vs wild type for MAb REGN10933.
@@ -1132,7 +1132,7 @@ D80A;L242del;A243del;L244del;R246I;K417N;E484K;N501Y;D614G;A701V
 # Wang et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.15.426911v2
 # Pseudotyped virus model ablates binding by RBD-directed mAbs CB6 and 910-30 (targeting the inner side of the RBD).
 # Pseudotyped virus model impairs binding by RBD-directed mAbs 4-20 and REGN10933.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 K417N
 
 # Ablates binding by class 2 mAbs such as C144 that directly interfere with ACE2 binding, 
@@ -1149,7 +1149,7 @@ K417N
 # Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w
 # Pseudotyped virus model ablates neutralization by RBD-directed mAbs 4-20, 2-4, 2-43, 2-30, 2-15, LY-Cov555, C121.
 # Pseudotyped virus model impairs neutralization by RBD-directed mAb COV2-2196 (somewhat more than fully pseudotyped B.1.351 or live virus)
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 # Massive reduction in binding efficiency vs wild type for mAb LY-CoV555.
 # Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
 E484K
@@ -1200,7 +1200,7 @@ T345A;L517R
 # 501Y.V2 ("South African") lineage background variant R246I to disrupt paratope binding. [PG: del extent simplified to accomodate minor position realignments]
 # Wibmer et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.18.427166v1
 # B.1.351 pseudotyped virus model ablates neutralization by N-terminal-domain-directed mAbs 5-24, 4-8, 4A8, 2-17, and 4-19 (independent of S:p.R246I).
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 L242del
 
 # Ablates binding of Spike N terminal domain targeting monoconal anibody 4A8, this residue is known to be key for CDR-H1 mediated
@@ -1208,7 +1208,7 @@ L242del
 # via steric clash with residue R102.
 # Wibmer et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.18.427166v1
 # B.1.351 pseudotyped virus model ablates neutralization by N-terminal-domain-directed mAbs 5-24, 4-8, 4A8, and 4-19 (independent of S:pL242_L244del).
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 R246I
 
 # Markedly resistant to neutralizing antibodies, unlike most ablated N-glycosylation sites.
@@ -1344,7 +1344,7 @@ S12F
 # McCallum et al. (2021) https://doi.org/10.1101/2021.01.14.426475
 # Ablates neutralization by N-terminal-domain-targeting mAbs 4-19.
 # Impairs neutralization by N-terminal-domain-targeting mAbs 4A8 and 2-17.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 L18F
 
 # Massively decreases N terminal domain antigen recognition by supersite i mAbs S2L28, S2M28, S2X28, S2X333, 4A8.
@@ -1364,7 +1364,7 @@ K147T
 # Massive reduction in 4A8 monoclonal antibody EC50 (i.e. ablated recognition) 
 # McCallum et al. (2021) https://doi.org/10.1101/2021.01.14.426475
 # Abolishes neutralization by N-terminal-domain-directed mAbs 5-24, 4-8, and 4A8.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 Y144del
 
 # Massive reduction in 4A8 monoclonal antibody EC50 (i.e. ablated recognition), but much milder effect on mAbs within antigenic supersite "i"

--- a/data/S_antibody_epitope_effects.txt
+++ b/data/S_antibody_epitope_effects.txt
@@ -1242,7 +1242,7 @@ A475V
 # 6.8% of 442 tested post-infection sera showed a greater than two-fold
 # reduction in binding to N439K RBD as compared to WT. In some individuals, the >two-fold reduction diminished the RBD ED50 response below 30
 # a threshold previously determined to be a cutoff for specific binding
-# Thomson et al. (2021) https://www.cell.com/cell/fulltext/S0092-8674(21)00080-5
+# Thomson et al. (2021) https://doi.org/10.1016/j.cell.2021.01.037
 # Ablates binding by class 3 mAbs such as C135 that do not directly interfere with ACE2 binding, 
 # but clonal somatic mutations of memory B cells at 6.2 months (evolving humoral immune response) 
 # show pronounced increase in binding to the variant. 

--- a/data/S_antibody_epitope_effects.txt
+++ b/data/S_antibody_epitope_effects.txt
@@ -915,11 +915,11 @@ N501Y
 D80A;D215G;L242del;A243del;L244del;K417N;E484K;N501Y;D614G;A701V
 
 # Of 50 mAbs tested, major loss of neutralization observed for S2X128, S2D8, S2X192, S2D19, S2H14, S2H19.
-# Collier et al. (2021) https://www.nature.com/articles/s41586-021-03412-7
+# Collier et al. (2021) https://doi.org/10.1038/s41586-021-03412-7
 N501Y
 
 # Of 50 mAbs tested, major loss of neutralization observed for S2N28, S2X615, S2N12, S2X192, S2H7, S2X16, S2X58, S2H70, S2X613, S2D19, S2N22, S2D32, S2H58, S2M11, S2D106, S2X30.
-# Collier et al. (2021) https://www.nature.com/articles/s41586-021-03412-7
+# Collier et al. (2021) https://doi.org/10.1038/s41586-021-03412-7
 E484K
 
 # Amongst RBD-targeting Emergency Use Authorized monoclonal antibody treatments CB6, LY-CoV555 and REGN10933 show abrogated neutralization activity against the

--- a/data/S_antibody_epitope_effects.txt
+++ b/data/S_antibody_epitope_effects.txt
@@ -1261,7 +1261,7 @@ N439K
 # Abolishes binding of mAb ADG-1.
 # Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 # N501Y substitution decreased the neutralizing and binding activities of CB6 and increased that of BD-23
-# Cheng et al. (2021) https://virologyj.biomedcentral.com/articles/10.1186/s12985-021-01554-8
+# Cheng et al. (2021) https://doi.org/10.1186/s12985-021-01554-8
 N440K
 
 # Ablates binding by class 3 mAbs such as C135 that do not directly interfere with ACE2 binding, 

--- a/data/S_convalescent_plasma_escape.txt
+++ b/data/S_convalescent_plasma_escape.txt
@@ -1112,51 +1112,51 @@ F140del
 E484K
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 Y145del
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 Q414E
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 N439K
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 G446V
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 K458N
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 I472V
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 A475V
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 T478I
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 V483I
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
 # Resistent to 3 individual sera at >4x
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 F490L
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
 # Resistent to 3 individual sera at >4x
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 H519P
 
 # Resistant to a pool of 10 convalescent sera (but less than 4x, a typical threshold for definition of escape)
-# Li et al. (2020) https://www.sciencedirect.com/science/article/abs/pii/S0092867420308771
+# Li et al. (2020) https://doi.org/10.1016/j.cell.2020.07.012
 A831V

--- a/data/S_convalescent_plasma_escape.txt
+++ b/data/S_convalescent_plasma_escape.txt
@@ -759,7 +759,7 @@ E484Q
 # neutralization of all 16 convalescent sera tested, averaging WT ratio of 0.41+-0.08 (less dramatic than E484K). 
 # This amino acid emerges as an additional hotspot for immune evasion and a target for therapies, vaccines and diagnostics.
 # It has emerged independently in multiple lineages.
-# Alenquer et al. (2021) http://biorxiv.org/cgi/content/short/2021.04.22.441007
+# Alenquer et al. (2021) https://doi.org/10.1101/2021.04.22.441007
 # In 2 of 11 subjects' convalescent sera in an early+late mutational landscape analysis of the RBD, 
 # S484P shows a slightly resistent profile across both timepoints (i.e. resistant to immune cell somatic mutation evolution)
 # Greaney et al. (2021) https://doi.org/10.1016/j.chom.2021.02.003

--- a/data/S_convalescent_plasma_escape.txt
+++ b/data/S_convalescent_plasma_escape.txt
@@ -507,13 +507,13 @@ N501Y;K417N;E484K
 
 # Using a new rapid neutralization assay, based on reporter cells that become positive for GFP after overnight infection, sera from 58 
 # convalescent individuals collected up to 9 months after symptoms, similarly neutralized B.1.1.7 and D614G. 
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 H69del;V70del;Y144del;N501Y;A570D;D614G;P681H;T716I;S982A;D1118H
 
 # Using a new rapid neutralization assay, based on reporter cells that become positive for GFP after overnight infection, sera from 58 
 # convalescent individuals collected up to 9 months after symptoms had mean ~6x reduction in neutralizing titers, and 40% of the samples 
 # lacked any activity against B.1.351. 
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 L18F;D80A;D215G;L242del;K417N;E484K;N501Y;D614G;A701V
 
 # Approximately 2-fold reduction in 15 ICU patient convalescent plasma neutralization as quantified by measuring virus-encoded 

--- a/data/S_convalescent_plasma_escape.txt
+++ b/data/S_convalescent_plasma_escape.txt
@@ -706,11 +706,11 @@ D80A;D215G;L242del;A243del;L244del;K417N;E484K;N501Y;D614G;A701V
 
 # Neutralization capacity GMT of 27 subjects' sera post-infection was considerably higher (stronger) than after the second 
 # Pfizer dose, and 4.5x drop in B.1.1.7 neutralization was observed.
-# Collier et al. (2021) https://www.nature.com/articles/s41586-021-03412-7
+# Collier et al. (2021) https://doi.org/10.1038/s41586-021-03412-7
 H69del;V70del;Y144del;N501Y;A570D;P681H;T716I;S982A;D1118H
 
 # Neutralization capacity GMT of 27 subjects' sera post-infection was markedly worse against B.1.1.7 + E484K than the lineage alone, with a 11.4x drop.
-# Collier et al. (2021) https://www.nature.com/articles/s41586-021-03412-7
+# Collier et al. (2021) https://doi.org/10.1038/s41586-021-03412-7
 H69del;V70del;Y144del;E484K;N501Y;A570D;P681H;T716I;S982A;D1118H
 
 # In convalescent sera one month or more post-infection in Spring 2020, an average 6.5x decrease in reciprocal ID50 value was observed 

--- a/data/S_convalescent_plasma_escape.txt
+++ b/data/S_convalescent_plasma_escape.txt
@@ -882,7 +882,7 @@ H69del;V70del;Y493F
 S982A
 
 # B.1.1.351 in 19 convalescent human sera ~1mo post infection had mild to moderate resistence against all samples
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 D80A,L242del;A243del;L244del;R246I;K417N;E484K;N501Y;D614G;A701V
 
 # Demonstrate (via competitive assays in human and mouse) immune escape from polyclonal antibodies induced
@@ -892,27 +892,27 @@ D80A,L242del;A243del;L244del;R246I;K417N;E484K;N501Y;D614G;A701V
 # reduced as confirmed here.
 # Vogel et al. (2021) https://www.biorxiv.org/content/10.1101/2021.03.04.433887v1
 # In 19 convalescent human sera ~1mo post infection had mild to moderate resistence against most samples
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 K417N;E484K;N501Y 
 
 # In 19 convalescent human sera ~1mo post infection had mild to moderate resistence against all samples. 
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 E484K;N501Y
 
 # B.1.1.248 variant constellation in 10 convalescent human sera ~1mo post infection had mild to moderate resistence against most samples, P=0.0020.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 L18F;T20N;P26S;D138Y;R190S;K417T;E484K;N501Y;D614G;H655Y;T1027I;V1176F
 
 # In 19 convalescent human sera ~1mo post infection, Two-tailed Wilcoxon matched-pairs signed-rank test shows mild resistence P=0.0361.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 K417N
 
 # B.1.1.7 variant constellation two-tailed Wilcoxon matched-pairs signed-rank test against 10 convalescent sera P=0.0039 for mild resistence.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 L18F;T20N;P26S;D138Y;R190S;K417T;E484K;N501Y;D614G;H655Y;T1027I;V1176F
 
 # B.1.1.351 variant constellation two-tailed Wilcoxon matched-pairs signed-rank test against 10 convalescent sera P=0.0020 for moderate resistence.
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 D80A,L242del;A243del;L244del;R246I;K417N;E484K;N501Y;D614G;A701V
 
 # Remarkably, several of the E484 escape mutants were resistant to neutralization at the highest

--- a/data/S_convalescent_plasma_escape.txt
+++ b/data/S_convalescent_plasma_escape.txt
@@ -1050,7 +1050,7 @@ S477N,S514F
 # The 501Y.V2 to first wave IC50 ratio ranged from 6 to 200-fold. Averaging across all 7 participant convalescent sera highlighted the dramatic
 # decrease in sensitivity to neutralization of authentic 501Y.V2 variants.
 # PG: I'm purposefully ignoring D614G and A701V as contributors
-# Cele et al. (2021) https://www.krisp.org.za/manuscripts/MEDRXIV-2021-250224v1-Sigal.pdf
+# Cele et al. (2021) https://doi.org/10.1038/s41586-021-03471-w
 L18F,D80A,D215G,L242del,A243del,L244del,K417N,E484K,N501Y
 
 # 27% of 44 early pandemic exposure convalescent plasma/sera lose all activity against a RBD triple mutant pseudovirus (RBD mutatants of the 501Y.V2 "South African" lineage), while only 23% retained high titres 

--- a/data/S_convalescent_plasma_escape.txt
+++ b/data/S_convalescent_plasma_escape.txt
@@ -836,16 +836,16 @@ S13I;W152C;L452R
 
 # The neutralizing activity of 16/20 convalescent sera was significantly lower against this pseudotyped virus model of B.1.351,
 # with similar results for the live virus.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 L18F,D80A,D215G,L242del;A243del;L244del;R246I;K417N;E484K;N501Y;D614G;A701V
 
 # The neutralizing activity of 8/20 convalescent sera was significantly lower against this pseudotyped virus model
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 L242del;A243del;L244del
 
 # The neutralizing activity of 8/20 convalescent sera was significantly lower against this pseudotyped virus model of B.1.1.7,
 # yet almost no effect was detected using the live B.1.1.7 virus.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 # Neutralization activity of convalescent sera tested decreased <2x with this B.1.1.7 pseudotyped virus.
 # Shen et al. (2021) https://www.biorxiv.org/content/10.1101/2021.01.27.428516v2
 # Maximum fold-decrease in potency for the serum samples from mild illness was 8.2 but the 
@@ -878,7 +878,7 @@ H69del;V70del;Y493F
 
 # The neutralizing activity of 6/20 convalescent sera was significantly lower against this single variant pseudotyped virus model,
 # showing similar patterns to the pseudotyped virus model of B.1.1.7.
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 S982A
 
 # B.1.1.351 in 19 convalescent human sera ~1mo post infection had mild to moderate resistence against all samples
@@ -920,7 +920,7 @@ D80A,L242del;A243del;L244del;R246I;K417N;E484K;N501Y;D614G;A701V
 # Against a wider panel of 16 convalescent plasma (no replicates), all but one show major resistance.
 # Liu et al. (2021) https://www.biorxiv.org/content/10.1101/2020.11.06.372037v2
 # The neutralizing activity of 15/20 convalescent sera was significantly lower against this pseudotyped virus model
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 E484K
 
 # Remarkably, several of the E484 escape mutants were resistant to neutralization at the highest

--- a/data/S_homoplasy.txt
+++ b/data/S_homoplasy.txt
@@ -9,7 +9,7 @@
 g.C24034U
 
 # Mutation has arisen independently multiple times, twice forming significant lineages
-# Thomson et al. (2021) https://www.cell.com/cell/fulltext/S0092-8674(21)00080-5
+# Thomson et al. (2021) https://doi.org/10.1016/j.cell.2021.01.037
 N439K
 
 # Variant within the six key residues in the receptor binding domain (RBD). Independently reported in UK, Australia 

--- a/data/S_homoplasy.txt
+++ b/data/S_homoplasy.txt
@@ -14,7 +14,7 @@ N439K
 
 # Variant within the six key residues in the receptor binding domain (RBD). Independently reported in UK, Australia 
 # (same origin as UK), and South Africa (independent origin).
-# Flores-Alanis et al. (2021) https://www.mdpi.com/2076-0817/10/2/184/htm
+# Flores-Alanis et al. (2021) https://doi.org/10.3390/pathogens10020184
 N501Y
 
 # In experimental models of SARS-CoV-2 mutational evolution (without immune pressure), this mutation in the N terminal domain appears 

--- a/data/S_immunosuppression_variant_emergence.txt
+++ b/data/S_immunosuppression_variant_emergence.txt
@@ -28,7 +28,7 @@ Y453F;H69del;V70del
 # Emergent as 100% variant from larger minor (1% allele frequency) deletion by day 70 post-infection of female immunocompromised 
 # individual with chronic lymphocytic leukemia and acquired hypogammaglobulinemia. Variant disappeared after convalescent plasma treatment (day 71)
 # in subsequent sample sequencing.
-# Avanzato et al. (2020) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7640888/
+# Avanzato et al. (2020) https://doi.org/10.1016%2Fj.cell.2020.10.049
 L141del,G142del,V143del,Y144del
 
 # Appeared (day 128) and persisted in chronic (152 day) SARS-CoV-2 infection of immunocompromised patient with severe antiphospholipid syndrome

--- a/data/S_monoclonal_antibody_serial_passage_escape.txt
+++ b/data/S_monoclonal_antibody_serial_passage_escape.txt
@@ -1307,7 +1307,7 @@ G496H
 # Strong positive selection (up to 44% of supernatant sequences) after after one round of C144 monoclonal antibody passage, then waning on subsequent passages
 # Weisblum et al. (2020) https://www.biorxiv.org/content/10.1101/2020.07.21.214759v1.full.pdf
 # The engineered mutation cause 10-fold or more increase in the disassociation constant with many monoclonal antibodies (C144/C002/C121/C104/C110).
-# Barnes et al. (2020) https://www.nature.com/articles/s41586-020-2852-1_reference.pdf?origin=ppub
+# Barnes et al. (2020) https://doi.org/10.1038/s41586-020-2852-1
 # Mildly effective mutant against this position in the RBD for highly neutralizing COV2-2479 monoclonal antibody
 # Effective mutant against this position in the RBD for highly neutralizing COV2-2050 monoclonal antibody
 # Greaney et al. (2020) https://doi.org/10.1016/j.chom.2020.11.007
@@ -1434,7 +1434,7 @@ R346K
 # Strong positive selection (up to 37% of supernatant sequences) after two rounds of C135 monoclonal antibody passage, overall 76% switch away from Q493 to K or R
 # Weisblum et al. (2020) https://www.biorxiv.org/content/10.1101/2020.07.21.214759v1.full.pdf
 # The engineered mutation cause 10-fold or more increase in the disassociation constant with C144, C002 and C121 monoclonal antibodies vs. wild type Spike protein RBD domain AAs.
-# Barnes et al. (2020) https://www.nature.com/articles/s41586-020-2852-1_reference.pdf?origin=ppub
+# Barnes et al. (2020) https://doi.org/10.1038/s41586-020-2852-1
 # Escape mutation against monoclonal antibody LY-CoV555 (antibody that forms the basis for Eli Lilly's bamlanivimab)
 # Starr et al. (2021) https://www.biorxiv.org/content/10.1101/2021.02.17.431683v1
 # Class 2 mAb C627 modestly selected for the emergence of this mutation in vitro.
@@ -1454,7 +1454,7 @@ Q493F
 Q493W
 
 # The engineered mutation cause 10-fold or more increase in the disassociation constant with C102, C105 and C144 monoclonal antibodies vs. wild type Spike protein RBD domain AAs.
-# Barnes et al. (2020) https://www.nature.com/articles/s41586-020-2852-1_reference.pdf?origin=ppub
+# Barnes et al. (2020) https://doi.org/10.1038/s41586-020-2852-1
 A475V
 
 # Escape variant 45% appearance in 2 passages against Regeneron monoclonal antibody RGN10987 @ 10ug/mL

--- a/data/S_outcome_hazard_ratio.txt
+++ b/data/S_outcome_hazard_ratio.txt
@@ -49,7 +49,7 @@ T95I;D253G;D614G
 # pre-existing variants after adjustment for age, sex, ethnicity, deprivation, residence in a care home, the local authority of residence and test date. 
 # This corresponds to the absolute risk of death for a 55–69-year-old man increasing from 
 # 0.6% to 0.9% (95% confidence interval, 0.8–1.0%) within 28 days of a positive test in the community.
-# Davies et al. (2021) https://www.nature.com/articles/s41586-021-03426-1
+# Davies et al. (2021) https://doi.org/10.1038/s41586-021-03426-1
 # 341 samples collected Nov 9 to Dec 20, 2020 were sequenced from two London (UK) hospitals. 
 # 198 (58%) of 341 had B.1.1.7 infection and 143 (42%) had non-B.1.1.7 infection. No evidence was found of an association 
 # between severe disease and death and lineage (B.1.1.7 vs non-B.1.1.7) in unadjusted analyses (prevalence ratio [PR] 0·97 

--- a/data/S_outcome_hazard_ratio.txt
+++ b/data/S_outcome_hazard_ratio.txt
@@ -39,7 +39,7 @@ T95I;D253G;D614G
 # Significant increase in hospitalization rate (11% vs 7.5% for non-VOC cases).
 # Significant increase in ICU rate (1.4% vs 0.6% for non-VOC cases).
 # Significant decrease in death rate (2.0% vs vs 4.0% for non-VOC cases).
-# Funk et al. (2021) https://www.eurosurveillance.org/content/10.2807/1560-7917.ES.2021.26.16.2100348
+# Funk et al. (2021) https://doi.org/10.2807/1560-7917.ES.2021.26.16.2100348
 # The matching-adjusted conditional odds ratio of hospitalisation was 1.58 (95% confidence interval 1.50 to 1.67) for COVID-19 patients 
 # infected with a SGTF-associated variant [primarily B.1.1.7], compared to those infected with non-SGTF-associated variants. 
 # The effect was modified by age (p<0.001), with ORs of 0.96-1.13 below age 20 years and 1.57-1.67 in age groups 40 years or older.
@@ -78,7 +78,7 @@ H69del;V70del;Y144del;N501Y;A570D;P681H;T716I;S982A;D1118H
 # Significant increase in hospitalization rate (20% vs 7.5% for non-VOC cases).
 # Significant increase in ICU rate (2.1% vs 0.6% for non-VOC cases).
 # Significant increase in health care worker rate (19.8% vs 8.0% for non-VOC cases).
-# Funk et al. (2021) https://www.eurosurveillance.org/content/10.2807/1560-7917.ES.2021.26.16.2100348
+# Funk et al. (2021) https://doi.org/10.2807/1560-7917.ES.2021.26.16.2100348
 # In the Parana state of Brazil, patients aged 20-29 years experienced a tripling of their case fatality rate (CFR), from 0.04% to 0.13%, while those aged 
 # 30-39, 40-49, 50-59 experienced approximate CFR doubling comparing February to January in 2021. Notably, 
 # the observed CFR increase coincided with the second consecutive month of declining number of diagnosed SARS-CoV-2 cases. 
@@ -94,5 +94,5 @@ L18F;K417T;E484K;N501Y;H655Y
 # Significant increase in hospitalization rate (19.3% vs 7.5% for non-VOC cases).
 # Significant increase in ICU rate (2.3% vs 0.6% for non-VOC cases).
 # PG: seems to be different notations around the LAL deletion, using the minimal shared definition to catch as many as possible.
-# Funk et al. (2021) https://www.eurosurveillance.org/content/10.2807/1560-7917.ES.2021.26.16.2100348
+# Funk et al. (2021) https://doi.org/10.2807/1560-7917.ES.2021.26.16.2100348
 D80A;D215G;L242del;K417N;E484K;N501Y;D614G;A701V

--- a/data/S_outcome_hazard_ratio.txt
+++ b/data/S_outcome_hazard_ratio.txt
@@ -32,7 +32,7 @@ T95I;D253G;D614G
 # consortium members show elevated ratios (~1.3-1.7x).
 # NERVTAG Consortium (2021) https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/961042/S1095_NERVTAG_update_note_on_B.1.1.7_severity_20210211.pdf
 # Danish study of the B.1.1.7 lineage shows hospital admission odds ratio of 1.63 vs other lineages. The adjusted OR was increased in all strata of age.
-# Bager et al. (2021) https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3792894
+# Bager et al. (2021) https://dx.doi.org/10.2139/ssrn.3792894
 # On average across 7 European countries studied, using B.1.1.7 defining mutations:
 # Significant shift to asymptomatic cases (27.4% vs 18.6% for non-VOC cases). 
 # Significant shift to infection in those without pre-existing conditions (44.8% vs 89% for non-VOC cases).

--- a/data/S_outcome_hazard_ratio.txt
+++ b/data/S_outcome_hazard_ratio.txt
@@ -43,7 +43,7 @@ T95I;D253G;D614G
 # The matching-adjusted conditional odds ratio of hospitalisation was 1.58 (95% confidence interval 1.50 to 1.67) for COVID-19 patients 
 # infected with a SGTF-associated variant [primarily B.1.1.7], compared to those infected with non-SGTF-associated variants. 
 # The effect was modified by age (p<0.001), with ORs of 0.96-1.13 below age 20 years and 1.57-1.67 in age groups 40 years or older.
-# Nyberg et al. (2021) https://arxiv.org/abs/2104.05560
+# Nyberg et al. (2021) https://doi.org/10.48550/arXiv.2104.05560
 # Using UK data 1 November 2020 to 14 February 2021, while correcting for misclassification of PCR test Spike Gene Target Failure (SGTF)
 # and missingness in SGTF status, we estimate that the hazard of death associated with B.1.1.7 is 61% (42–82%) higher than with 
 # pre-existing variants after adjustment for age, sex, ethnicity, deprivation, residence in a care home, the local authority of residence and test date. 

--- a/data/S_pharmaceutical_effectiveness.txt
+++ b/data/S_pharmaceutical_effectiveness.txt
@@ -132,7 +132,7 @@ D614G
 P681H
 
 # Greater than 10-fold rediuction of binding effeiency vs wild type for mAb LY-CoV555.
-# Rappazzo et al. (2021) https://science.sciencemag.org/content/371/6531/823
+# Rappazzo et al. (2021) https://doi.org/10.1126/science.abf4830
 F490S
 
 # This Spike pseudotype for Day 146 virus from a chronically infected patient was completely resistent to REGN10933.

--- a/data/S_tissue_specific_neutralization.txt
+++ b/data/S_tissue_specific_neutralization.txt
@@ -2,18 +2,18 @@
 # swab from different previously infected vacinee neutralizing at weeks 3 and 6 against B.1.1.7 and D614G) suggest that vaccinees probably 
 # do not elicit an early humoral response detectable at mucosal surfaces even though sera neutralization was observed. They strengthen the hypothesis that some vaccines may not protect against 
 # viral acquisition and infection of the oral–nasal region, but may prevent severe disease associated with viral dissemination in the lower respiratory tract. 
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 H69del;V70del;Y144del;N501Y;A570D;D614G;P681H;T716I;S982A;D1118H
 
 # The nasal mucosa of Pfizer vaccinees with time course collection was evaluated against VSV pseudotypes: results (only one nasal 
 # swab from different previously infected vacinee neutralizing at weeks 3 and 6 against B.1.1.7 and D614G) suggest that vaccinees probably 
 # do not elicit an early humoral response detectable at mucosal surfaces even though sera neutralization was observed. They strengthen the hypothesis that some vaccines may not protect against 
 # viral acquisition and infection of the oral–nasal region, but may prevent severe disease associated with viral dissemination in the lower respiratory tract. 
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 D614G
 
 # The nasal mucosa of Pfizer vaccinees with time course collection was evaluated against VSV pseudotypes: while B.1.1.7 and D614G showed neutralization
 # by nasal swab from only one different previously infected vacinee neutralizing at weeks 3 and 6, B.1.351 showed zero neutralization at either time point
 # in any sample (and relatively impaired serum neutralization).
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 L18F;D80A;D215G;L242del;K417N;E484K;N501Y;D614G;A701V

--- a/data/S_trafficking.txt
+++ b/data/S_trafficking.txt
@@ -504,7 +504,7 @@ A831V
 # Zhang et l. (2020) https://doi.org/10.1038/s41467-020-19808-4
 # Among S variants tested, the D614G mutant shows the highest cell entry (~3.5x wild type), as supported by 
 # structural and binding analyses. 
-# Ozono et al. (2020) https://www.nature.com/articles/s41467-021-21118-2
+# Ozono et al. (2020) https://doi.org/10.1038/s41467-021-21118-2
 # The increased transduction with Spike D614G ranged from 1.3- to 2.4-fold in Caco-2 and Calu-3 cells expressing 
 # endogenous ACE2 and from 1.5- to 7.7-fold in A549ACE2 and Huh7.5ACE2 overexpressing ACE2. 
 # Although there is minimal difference in ACE2 receptor binding between the D614 and G614 Spike variants, 

--- a/data/S_trafficking.txt
+++ b/data/S_trafficking.txt
@@ -501,7 +501,7 @@ A831V
 # This increased entry correlates with less S1-domain shedding and higher S-protein incorporation into the virion. 
 # D614G does not alter S-protein binding to ACE2 or neutralization sensitivity of pseudoviruses. Thus, D614G may 
 # increase infectivity by assembling more functional S protein into the virion.
-# Zhang et l. (2020) https://www.nature.com/articles/s41467-020-19808-4
+# Zhang et l. (2020) https://doi.org/10.1038/s41467-020-19808-4
 # Among S variants tested, the D614G mutant shows the highest cell entry (~3.5x wild type), as supported by 
 # structural and binding analyses. 
 # Ozono et al. (2020) https://www.nature.com/articles/s41467-021-21118-2

--- a/data/S_transmissibility.txt
+++ b/data/S_transmissibility.txt
@@ -76,7 +76,7 @@ N440K
 # We estimate that this [B.1.1.17] variant has a 43–90% (range of 95% credible intervals 38–130%) higher reproduction number than preexisting variants.
 # Data from other countries yield similar results: we estimate that R for VOC 202012/01 relative to other lineages is 55% (45–66%) higher in Denmark, 
 # 74% (66–82%) higher in Switzerland, and 59% (56–63%) higher in the United States, with consistent rates of displacement across regions within each country.
-# Davies et al. (2021) https://science.sciencemag.org/content/early/2021/03/02/science.abg3055
+# Davies et al. (2021) https://doi.org/10.1126/science.abg3055
 # Primary cases infected with B.1.1.7 had an increased transmissibility of 1.5-1.7 times that of primary cases infected with other 
 # lineages. The increased transmissibility of B.1.1.7 was multiplicative across age and viral load.
 # Lyngse et al. (2021) https://www.medrxiv.org/content/10.1101/2021.04.16.21255459v1

--- a/data/S_vaccine_neutralization_efficacy.txt
+++ b/data/S_vaccine_neutralization_efficacy.txt
@@ -962,18 +962,18 @@ D80A;D215G;L242del;K417N;E484K;N501Y;D614G;A701V
 L18F,D80A,D215G,L242del;R246I;K417N;E484K;N501Y;D614G;A701V
 
 # The neutralizing activity of vaccine was significantly lower against B.1.351 in sera from all 24 patients with the BNT162b2 mRNA vaccine. (Fig. 4)
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 D80A,L242del;R246I;K417N;E484K;N501Y;D614G;A701V
 
 # The neutralizing activity of vaccine was slightly lower against B.1.1.248 variant constellation in sera tested from most of the 15 patients with 
 # the BNT162b2 mRNA vaccine. (Fig. 4)
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 L18F;T20N;P26S;D138Y;R190S;K417T;E484K;N501Y;D614G;H655Y;T1027I;V1176F
 
 # The neutralizing activity of vaccine was slightly to significantly lower against this variant combination in sera from all 24 patients with 
 # the BNT162b2 mRNA vaccine. (Fig. 4)
 # [In stark contrast to this combination plus K417N, which had no effect (P<0.0001 vs. P=0.8774)]
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w
 # In 20 sera from BNT162b2 mRNA vaccine inoculated participants, 6 displayed mild (2x) reductions in neutralization.
 # This variant combination showed the highest reduction, but the magnitude of the differences was small 
 # compared to the >4x differences in HA-inhibition titers that have been used to signal potential need for a strain change in influenza vaccines.
@@ -981,7 +981,7 @@ L18F;T20N;P26S;D138Y;R190S;K417T;E484K;N501Y;D614G;H655Y;T1027I;V1176F
 E484K;N501Y
 
 # The neutralizing activity of vaccine was somewhat lower against B.1.1.7 in sera tested from most of the 24 patients with the BNT162b2 mRNA vaccine. (Fig. 4)
-# Chen et al. (2021) https://www.nature.com/articles/s41591-021-01294-w 
+# Chen et al. (2021) https://doi.org/10.1038/s41591-021-01294-w 
 H69del;V70del;Y144del;Y145del;N501Y;A570D;D614G;P681H
 
 # Pseudotyped B.1.1.7 Spike variants lentivirus.

--- a/data/S_vaccine_neutralization_efficacy.txt
+++ b/data/S_vaccine_neutralization_efficacy.txt
@@ -693,7 +693,7 @@ S13I;W152C;L452R
 # Lineage B.1.1.7 spike–pseudotyped VSV was tested for neutralization vs Wuhan reference genome pseudotype in 40 sera collected
 # 7 or 21 days post-booster dose. Statistically significant change (22%) in neutralization was observed among the 26 sera from those <=55yo, 
 # but not in the 14 sera from those >55yo. A ~20% change is not considered immunologically significant historically in influenza antibody studies. 
-# Muik et al. (2021) https://science.sciencemag.org/content/371/6534/1152
+# Muik et al. (2021) https://doi.org/10.1126/science.abg6105
 # Vaccine elicited antibodies neutralized virus with the B.1.1.7 spike protein with titers similar to D614G virus. Serum specimens 
 # from individuals vaccinated with the BNT162b2 mRNA vaccine neutralized D614G virus with titers that were on average 7-fold greater than convalescent sera.
 # Tada et al. (2021) https://doi.org/10.1101/2021.02.05.430003

--- a/data/S_vaccine_neutralization_efficacy.txt
+++ b/data/S_vaccine_neutralization_efficacy.txt
@@ -554,14 +554,14 @@ L452R
 # The sera of 16 individuals with time course collection was evaulated against VSV pseudotypes: neutralized D614G at week 2, 
 # whereas B.1.1.7 started to be neutralized at week 3, although less efficiently than D614G. B.1.1.7 and D614G strains were 
 # similarly neutralized at week 4 (1 week after booster dose). 
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 H69del;V70del;Y144del;N501Y;A570D;D614G;P681H;T716I;S982A;D1118H
 
 # The sera of 16 individuals with time course collection was evaluated against VSV pseudotypes: while BD614G and B.1.1.7 were 
 # neutralized earlier, the anti-B.1.351 response was negative up to week 3, and became detectable at week 4 (1 week after booster dose), at a level lower 
 # than the two other viruses (~10x vs D614G) through week 6, the last timepoint measured. Three vaccinees never showed detectable neutralization
 # to B.1.351 even after second dose.
-# Planas et al. (2021) https://www.nature.com/articles/s41591-021-01318-5
+# Planas et al. (2021) https://doi.org/10.1038/s41591-021-01318-5
 # [Contrary to how this paper has been cited, Voysey et al. do NOT show evidence of decreased effectiveness of ChAdOx1 (AstraZeneca) against 
 # the South African B.1.351 lineage. Insufficient numbers reaching the primary study endpoint were available in that arm of the vaccine study
 # to report any statistics from the South African participants. Additionally, the study period of the paper ended in November 2020, while

--- a/data/S_vaccine_neutralization_efficacy.txt
+++ b/data/S_vaccine_neutralization_efficacy.txt
@@ -954,7 +954,7 @@ D80A;D215G;L242del;K417N;E484K;N501Y;D614G;A701V
 
 # The neutralizing activity of vaccine was significantly lower against B.1.351 (12.4x in twelve Moderna-recipient sera; 10.3x in ten Pfizer-recipient sera).
 # [this is a larger list of B.1.351 than modeled by Wang et al. (2021) by including L18F and R246I, less effective at neutralizing]
-# Wang et al. (2021) https://www.nature.com/articles/s41586-021-03398-2
+# Wang et al. (2021) https://doi.org/10.1038/s41586-021-03398-2
 # Neutralization efficiency (ID50) against B.1.1.351-v1 reduced 6.9x relative to D614G wildtype using pseudotyped VSV assay on 8 Moderna vaccinee sera one week post-booster.
 # Choi et al. (2021) https://www.biorxiv.org/content/10.1101/2021.06.28.449914v1
 # 3.2x reduction in neutralization (ID50) in sera 3 weeks after one dose of Pfizer/BioNTech BNT162b2 (up to 5 naive and post infection vaccinees)

--- a/data/S_vaccine_neutralization_efficacy.txt
+++ b/data/S_vaccine_neutralization_efficacy.txt
@@ -839,7 +839,7 @@ H69del;V70del;Y145del;N501Y;A570D;D614G;P681H;T716I;S982A;D1118H
 
 # Sera after the second dose of Pfizer showed an average reduction in neutralization titres against the B.1.1.7 + E484K 
 # variant of ~6.7x, markedly higher than B.1.1.7 alone. For first dose sera, a 9.7x drop was observed.
-# Collier et al. (2021) https://www.nature.com/articles/s41586-021-03412-7
+# Collier et al. (2021) https://doi.org/10.1038/s41586-021-03412-7
 # Neutralization efficiency (ID50) against B.1.1.7+E484K reduced 2.8x relative to D614G wildtype using pseudotyped VSV assay on 8 Moderna vaccinee sera one week post-booster.
 # Compare with 1.2x reduction for B.1.1.7 without E484K.
 # Choi et al. (2021) https://www.biorxiv.org/content/10.1101/2021.06.28.449914v1
@@ -848,7 +848,7 @@ H69del;V70del;Y144del;E484K;N501Y;A570D;P681H;T716I;S982A;D1118H
 # 20/29 sera after the first dose of Pfizer showed an average reduction in neutralization titres against the B.1.1.7 variant of 3.2 ± 5.7.
 # After the second dose, the GMT was markedly increased compared with the first-dose titres, with a fold change of 1.9 ± 0.9 (mean ± s.d.).
 # Neutralization GMT of 27 subjects post-infection was considerably higher (stronger) than after the second Pfizer dose, and 4.5x drop in B.1.1.7 neutralization was observed.
-# Collier et al. (2021) https://www.nature.com/articles/s41586-021-03412-7
+# Collier et al. (2021) https://doi.org/10.1038/s41586-021-03412-7
 H69del;V70del;Y144del;N501Y;A570D;P681H;T716I;S982A;D1118H
 
 # Pzifer vaccinees that tested positive at least a week after the second dose were indeed disproportionally infected with B.1.351, 

--- a/data/S_vaccine_neutralization_efficacy.txt
+++ b/data/S_vaccine_neutralization_efficacy.txt
@@ -977,7 +977,7 @@ L18F;T20N;P26S;D138Y;R190S;K417T;E484K;N501Y;D614G;H655Y;T1027I;V1176F
 # In 20 sera from BNT162b2 mRNA vaccine inoculated participants, 6 displayed mild (2x) reductions in neutralization.
 # This variant combination showed the highest reduction, but the magnitude of the differences was small 
 # compared to the >4x differences in HA-inhibition titers that have been used to signal potential need for a strain change in influenza vaccines.
-# Xie et al. (2021) https://www.nature.com/articles/s41591-021-01270-4
+# Xie et al. (2021) https://doi.org/10.1038/s41591-021-01270-4
 E484K;N501Y
 
 # The neutralizing activity of vaccine was somewhat lower against B.1.1.7 in sera tested from most of the 24 patients with the BNT162b2 mRNA vaccine. (Fig. 4)

--- a/data/S_vaccine_neutralization_efficacy.txt
+++ b/data/S_vaccine_neutralization_efficacy.txt
@@ -405,7 +405,7 @@ E484K
 # of the ChAdOx1-S vaccine was about 60-75% effective against symptomatic disease and provided an additional protective effect against hospital 
 # admission—it is too early to assess the effect on mortality. The B.1.1.7 variant now dominates in the UK and these results will largely 
 # reflect vaccine effectiveness against this variant.
-# Lopez Bernal et al. (2021) https://pubmed.ncbi.nlm.nih.gov/33985964/
+# Lopez Bernal et al. (2021) https://doi.org/10.1136/bmj.n1088
 # SARS-CoV-2 infection was confirmed in three HCWs working a single shift; all presented with mild symptoms of COVID-19. The two physicians 
 # were fully vaccinated with BNT162b2 vaccine, with the second dose administered 1 month before symptom onset. Both had high titres of IgG 
 # anti-spike antibodies at the time of diagnosis. WGS confirmed that all virus strains were VOC 202012/01-lineage B.1.1.7, suggesting a 

--- a/data/S_vaccine_neutralization_efficacy.txt
+++ b/data/S_vaccine_neutralization_efficacy.txt
@@ -623,7 +623,7 @@ E484K;F565L;D614G;V1176F
 # infection showed reduced immunity against variants. B.1.351 spike mutations 
 # resulted in increased, abrogated or unchanged T cell responses depending on human leukocyte 
 # antigen (HLA) polymorphisms. Study was 26 each post-infection and post first dose HCWs.
-# Reynolds et al. (2021) https://science.sciencemag.org/content/early/2021/04/29/science.abh1282
+# Reynolds et al. (2021) https://doi.org/10.1126/science.abh1282
 D80A;L242del;R246I;K417N;E484K;N501Y;A701V
 
 # ELISpot assays show T cell neutralization reduced by 29.8% in this B.1.351 pseudotype relative to wild type in 18-20 pooled patient samples post second mRNA vaccine dose,
@@ -644,7 +644,7 @@ L18F;T20N;P26S;D138Y;R190S;K417T;E484K;N501Y;D614G;H655Y;T1027I;V1176F
 # infection showed reduced immunity against variants. B.1.1.7 spike mutations 
 # resulted in increased, abrogated or unchanged T cell responses depending on human leukocyte 
 # antigen (HLA) polymorphisms. Study was 26 each post-infection and post first dose HCWs.
-# Reynolds et al. (2021) https://science.sciencemag.org/content/early/2021/04/29/science.abh1282
+# Reynolds et al. (2021) https://doi.org/10.1126/science.abh1282
 # ELISpot assays show T cell neutralization reduced by 15.4% in this B.1.1.7 pseudotype relative to wild type in 18-20 pooled patient samples post second mRNA vaccine dose,
 # with no significant difference between Pfizer and Moderna cohorts. Reduction was stronger in the S1 subunit than S2 (separate peptide pools were used).
 # Gallagher et al. (2021) https://www.biorxiv.org/content/10.1101/2021.05.03.442455v1

--- a/data/S_viral_load.txt
+++ b/data/S_viral_load.txt
@@ -44,7 +44,7 @@ H69del;V70del;Y144del;N501Y;A570D;P681H;T716I;S982A;D1118H
 
 # Hamsters infected with SARS-CoV-2 expressing spike(D614G) (G614 virus) produced higher infectious titres in nasal washes and the trachea, but not in the lungs, 
 # supporting clinical evidence showing that the mutation enhances viral loads in the upper respiratory tract of COVID-19 patients and may increase transmission.
-# Plante et al. (2020) https://www.nature.com/articles/s41586-020-2895-3
+# Plante et al. (2020) https://doi.org/10.1038/s41586-020-2895-3
 D614G
 
 # Swab samples N/NP viral RNA is approximately 2-fold higher in B.1.427/B.1.429 than in non-variant viruses.

--- a/data/S_virion_structure.txt
+++ b/data/S_virion_structure.txt
@@ -42,7 +42,7 @@ H69del;V70del;N501Y;P681H
 # Zhang et al. (2020) https://doi.org/10.1038/s41467-020-19808-4
 # CryoEM shows increased proportion of "one-up" trimer conformation of Spike proteins on the surface of virions, where the up 
 # conformation is presumed to be more likely to bind ACE2.
-# Yurkovetskiy et al. (2020) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7492024/
+# Yurkovetskiy et al. (2020) https://doi.org/10.1016%2Fj.cell.2020.09.032
 # Negative stain EM shows increased proportion of "one-up" trimer conformation of Spike proteins on the surface of virions, where the up 
 # conformation is presumed to be more likely to bind ACE2.
 # Weissman et al. (2020) https://www.medrxiv.org/content/10.1101/2020.07.22.20159905v2

--- a/data/S_virion_structure.txt
+++ b/data/S_virion_structure.txt
@@ -39,7 +39,7 @@ H69del;V70del;N501Y
 H69del;V70del;N501Y;P681H
 
 # Based on pseudotyped virus experiments, D614G may increase infectivity by assembling more functional S protein into the virion.
-# Zhang et al. (2020) https://www.nature.com/articles/s41467-020-19808-4
+# Zhang et al. (2020) https://doi.org/10.1038/s41467-020-19808-4
 # CryoEM shows increased proportion of "one-up" trimer conformation of Spike proteins on the surface of virions, where the up 
 # conformation is presumed to be more likely to bind ACE2.
 # Yurkovetskiy et al. (2020) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7492024/

--- a/data/nsp1_immunosuppression_variant_emergence.txt
+++ b/data/nsp1_immunosuppression_variant_emergence.txt
@@ -2,5 +2,5 @@
 # individual with chronic lymphocytic leukemia and acquired hypogammaglobulinemia. 
 # Variant became 100% in day 70 culture.
 # Variant disappeared after convalescent plasma treatment (day 71) in subsequent patient sample sequencing.
-# Avanzato et al. (2020) https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7640888/
+# Avanzato et al. (2020) https://doi.org/10.1016%2Fj.cell.2020.10.049
 M85del

--- a/data/nsp6_homoplasy.txt
+++ b/data/nsp6_homoplasy.txt
@@ -8,7 +8,7 @@ g.C11074U
 # High quality non-synonymous homoplasies from a paper, where functional fitness is presumed.
 # Van Dorp et al. (2020) https://doi.org/10.1016/j.meegid.2020.104351
 # PG: Directly flanks a lumenal (endoplasmic reticulum bound) domain, NSPs "rush to the ER" for assembly of the replication and transcriptional machinery.
-# Santerre et al. (2020) https://link.springer.com/article/10.1007/s00415-020-10197-8
+# Santerre et al. (2020) https://doi.org/10.1007/s00415-020-10197-8
 # PG: Effect is for reported homoplasy g.G11083T.
 # PG: This variant has appeared independently many times in the tree, and lead to multiple extended lineages. 
 # PG: G->T is not easily explained by base deamination or cross-linking artefacts.
@@ -25,5 +25,5 @@ L37F
 # a.k.a ORF1a:p.3675_3677del or NC_045512:g.11288_11296del
 # Rambaut (2021) https://github.com/cov-lineages/pango-designation/issues/4
 # PG: Directly flanks a lumenal (endoplasmic reticulum bound) domain, NSPs "rush to the ER" for assembly of the replication and transcriptional machinery.
-# Santerre et al. (2020) https://link.springer.com/article/10.1007/s00415-020-10197-8
+# Santerre et al. (2020) https://doi.org/10.1007/s00415-020-10197-8
 S106del,G107del,F108del

--- a/data/nsp6_homoplasy.txt
+++ b/data/nsp6_homoplasy.txt
@@ -16,7 +16,7 @@ g.C11074U
 # Could significantly modify COVID-19 pathogenicity by altering the host autophagic lysosomal antiviral machinery.
 # O'Leary and Ovsepian (2020) https://dx.doi.org/10.1016%2Fj.tig.2020.08.014
 # By analyzing the distribution of 11083G>T in various countries, we unveil that 11083G>T may correlate with the hypotoxicity of SARS-CoV-2...L37F has made NSP6 energetically less stable
-# Wang et al. (2020) https://arxiv.org/abs/2007.01344
+# Wang et al. (2020) https://doi.org/10.48550/arXiv.2007.01344
 # Destabilization of NSP6 also predicted in this paper.
 # Sadar et al. (2020) https://doi.org/10.1016/j.heliyon.2020.e04658 
 L37F


### PR DESCRIPTION
For Cele et al. (2021), the doi is for the later published version (not the preprint originally linked).
